### PR TITLE
Implement multiple streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Racoder is a lightweight Node.js web server that leverages [FFmpeg](https://ffmp
 
 Configuration options are set using environment variables.
 
-| Name         | Description                                                                                                                   | Default value | Example                                                                             |
-|--------------|-------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------|
-| INPUT_STREAM | ℹ️ Required. URL for incoming stream. Use `|` to separate multiple URLs.                                                       | N/A           | `https://artesimulcast.akamaized.net/hls/live/2030993/artelive_de/master_v180.m3u8` |
-| BITRATE      | Transcoding bitrate for output MP3 stream                                                                                     | `128k`        | `320k`                                                                              |
-| LOG_LEVEL    | Level of detail for log output                                                                                                | `INFO`        | `DEBUG`                                                                             |
-| OUTPUT_PATH  | URL path for output MP3 stream, must contain leading slash. Must be set, if multiple URLs are set and again separated by `|`. | `/`           | `/my-station`                                                                       |
-| TZ           | Timezone for log timestamps                                                                                                   | `UTC`         | `Europe/Berlin`                                                                     |
+| Name         | Description                                                                                                                    | Default value | Example                                                                             |
+|--------------|--------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------|
+| INPUT_STREAM | ℹ️ Required. URL for incoming stream. Use `\|` to separate multiple URLs.                                                       | N/A           | `https://artesimulcast.akamaized.net/hls/live/2030993/artelive_de/master_v180.m3u8` |
+| BITRATE      | Transcoding bitrate for output MP3 stream                                                                                      | `128k`        | `320k`                                                                              |
+| LOG_LEVEL    | Level of detail for log output                                                                                                 | `INFO`        | `DEBUG`                                                                             |
+| OUTPUT_PATH  | URL path for output MP3 stream, must contain leading slash. Must be set, if multiple URLs are set and again separated by `\|`. | `/`           | `/my-station`                                                                       |
+| TZ           | Timezone for log timestamps                                                                                                    | `UTC`         | `Europe/Berlin`                                                                     |
 
 ## How to deploy
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Racoder is a lightweight Node.js web server that leverages [FFmpeg](https://ffmp
 
 Configuration options are set using environment variables.
 
-| Name         | Description                               | Default value | Example                                                                             |
-| ------------ | ----------------------------------------- | ------------- | ----------------------------------------------------------------------------------- |
-| INPUT_STREAM | ℹ️ Required. URL for incoming stream      | N/A           | `https://artesimulcast.akamaized.net/hls/live/2030993/artelive_de/master_v180.m3u8` |
-| BITRATE      | Transcoding bitrate for output MP3 stream | `128k`        | `320k`                                                                              |
-| LOG_LEVEL    | Level of detail for log output            | `INFO`        | `DEBUG`                                                                             |
-| OUTPUT_PATH  | URL path for output MP3 stream            | `/`           | `/my-station`                                                                       |
-| TZ           | Timezone for log timestamps               | `UTC`         | `Europe/Berlin`                                                                     |
+| Name         | Description                                                                                                                   | Default value | Example                                                                             |
+|--------------|-------------------------------------------------------------------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------|
+| INPUT_STREAM | ℹ️ Required. URL for incoming stream. Use `|` to separate multiple URLs.                                                       | N/A           | `https://artesimulcast.akamaized.net/hls/live/2030993/artelive_de/master_v180.m3u8` |
+| BITRATE      | Transcoding bitrate for output MP3 stream                                                                                     | `128k`        | `320k`                                                                              |
+| LOG_LEVEL    | Level of detail for log output                                                                                                | `INFO`        | `DEBUG`                                                                             |
+| OUTPUT_PATH  | URL path for output MP3 stream, must contain leading slash. Must be set, if multiple URLs are set and again separated by `|`. | `/`           | `/my-station`                                                                       |
+| TZ           | Timezone for log timestamps                                                                                                   | `UTC`         | `Europe/Berlin`                                                                     |
 
 ## How to deploy
 
@@ -59,10 +59,10 @@ Here we are using the [BBC Radio 4 Extra HLS AAC stream](https://gist.github.com
 
 ### Using Docker Compose
 
-- [Simple Compose file example](https://github.com/paulgalow/racoder/blob/main/examples/docker-compose.simple.yml)
-- [Extended Compose file example](https://github.com/paulgalow/racoder/blob/main/examples/docker-compose.extended.yml)
+- [Simple Compose file example](./examples/docker-compose.simple.yml)
+- [Extended Compose file example](./examples/docker-compose.extended.yml)
 
 ### Using fly.io
 
-- [Simple Fly.io TOML example](https://github.com/paulgalow/racoder/blob/main/examples/fly.simple.toml)
-- [Extended Fly.io TOML example](https://github.com/paulgalow/racoder/blob/main/examples/fly.extended.toml)
+- [Simple Fly.io TOML example](./examples/fly.simple.toml)
+- [Extended Fly.io TOML example](./examples/fly.extended.toml)

--- a/examples/docker-compose.extended.yml
+++ b/examples/docker-compose.extended.yml
@@ -6,8 +6,8 @@ services:
     ports:
       - "3000:3000/tcp"
     environment:
-      INPUT_STREAM: "https://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_radio_four_extra/bbc_radio_four_extra.isml/bbc_radio_four_extra-audio%3d96000.norewind.m3u8"
-      OUTPUT_PATH: "/bbc-radio-4-extra"
+      INPUT_STREAM: "http://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_radio_one/bbc_radio_one.isml/bbc_radio_one-audio%3d96000.norewind.m3u8|http://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_radio_fourfm/bbc_radio_fourfm.isml/bbc_radio_fourfm-audio%3d96000.norewind.m3u8|https://as-hls-ww-live.akamaized.net/pool_904/live/ww/bbc_radio_four_extra/bbc_radio_four_extra.isml/bbc_radio_four_extra-audio%3d96000.norewind.m3u8"
+      OUTPUT_PATH: "/bbc-radio-1|/bbc-radio-4|/bbc-radio-4-extra"
       BITRATE: 128k
       TZ: Europe/Berlin
       LOG_LEVEL: DEBUG

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,7 +40,7 @@ export function validateEnv() {
   }
 
   try {
-    new URL(process.env.INPUT_STREAM);
+    process.env.INPUT_STREAM.split("|").map(function (val) { new URL(val);});
   } catch (error) {
     throw new Error("'INPUT_STREAM' environment variable is not a valid URL.");
   }
@@ -48,6 +48,11 @@ export function validateEnv() {
   if (process.env.OUTPUT_PATH == null) {
     log("'OUTPUT_PATH' environment variable is not set. Defaulting to '/' …");
     process.env.OUTPUT_PATH = "/";
+  }
+
+  const number_of_urls = process.env.INPUT_STREAM.split("|").length;
+  if (number_of_urls > 1 && number_of_urls != process.env.OUTPUT_PATH.split("|").length) {
+    throw new Error("If multiple urls are specified in 'INPUT_STREAM', 'OUTPUT_PATH' must be set and contain the same number of paths");
   }
 
   if (process.env.BITRATE == null) {


### PR DESCRIPTION
I implemented multiple streams into one process/container as discussed in #1.

Add extra URLs with `|` delimiter.
In that case, setting OUTPUT_PATH is required.

I choose pipe `|` since it isn't allowed in URLs, so there shouldn't be conflicts.

Concurrent access of different (or the same) streams seems to work.